### PR TITLE
added comments to set packageConfigPaths

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -409,6 +409,9 @@ export class SeedConfig {
     packageConfigPaths: [
       join('node_modules', '*', 'package.json'),
       join('node_modules', '@angular', '*', 'package.json')
+      // for other modules like @ngx-translate the package.json path needs to updated here
+      // otherwise npm run build.prod would fail
+      // join('node_modules', '@ngx-translate', '*', 'package.json')
     ],
     paths: {
       // Note that for multiple apps this configuration need to be updated


### PR DESCRIPTION
Adding extra modules won't fail the buld.prod task. Must ensure that packageConfigPaths are updated appropriately.